### PR TITLE
[WIP] Adding options conducive to small animal neuroimaging

### DIFF
--- a/package/niflow/ants/brainextraction/workflows/brainextraction.py
+++ b/package/niflow/ants/brainextraction/workflows/brainextraction.py
@@ -47,7 +47,8 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
                              atropos_refine=True,
                              atropos_use_random_seed=True,
                              atropos_model=None,
-                             use_laplacian=True):
+                             use_laplacian=True,
+                             bspline_fitting_distance=200):
     """
     A Nipype implementation of the official ANTs' ``antsBrainExtraction.sh``
     workflow (only for 3D images).
@@ -109,6 +110,8 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
         use_laplacian : bool
             Enables or disables alignment of the Laplacian as an additional
             criterion for image registration quality (default: True)
+        bspline_fitting_distance : float
+            The size of the b-spline mesh grid elements, in mm (default: 200)
 
 
     **Inputs**
@@ -196,7 +199,7 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
         N4BiasFieldCorrection(
             dimension=3, save_bias=True, copy_header=True,
             n_iterations=[50] * 4, convergence_threshold=1e-7, shrink_factor=4,
-            bspline_fitting_distance=200),
+            bspline_fitting_distance=bspline_fitting_distance),
         n_procs=omp_nthreads, name='inu_n4', iterfield=['input_image'])
 
     res_tmpl = pe.Node(ResampleImageBySpacing(out_spacing=(4, 4, 4),

--- a/package/niflow/ants/brainextraction/workflows/brainextraction.py
+++ b/package/niflow/ants/brainextraction/workflows/brainextraction.py
@@ -46,7 +46,8 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
                              modality='T1',
                              atropos_refine=True,
                              atropos_use_random_seed=True,
-                             atropos_model=None):
+                             atropos_model=None,
+                             use_laplacian=True):
     """
     A Nipype implementation of the official ANTs' ``antsBrainExtraction.sh``
     workflow (only for 3D images).
@@ -105,6 +106,9 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
             the defaults based on ``modality``
         name : str, optional
             Workflow name (default: antsBrainExtraction)
+        use_laplacian : bool
+            Enables or disables alignment of the Laplacian as an additional
+            criterion for image registration quality (default: True)
 
 
     **Inputs**
@@ -266,13 +270,9 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
         (trunc, inu_n4, [('output_image', 'input_image')]),
         (inu_n4, res_target, [
             (('output_image', _pop), 'input_image')]),
-        (inu_n4, lap_target, [
-            (('output_image', _pop), 'op1')]),
         (res_tmpl, init_aff, [('output_image', 'fixed_image')]),
         (res_target, init_aff, [('output_image', 'moving_image')]),
         (inu_n4, mrg_target, [('output_image', 'in1')]),
-        (lap_tmpl, mrg_tmpl, [('output_image', 'in2')]),
-        (lap_target, mrg_target, [('output_image', 'in2')]),
 
         (init_aff, norm, [('output_transform', 'initial_moving_transform')]),
         (mrg_tmpl, norm, [('out', 'fixed_image')]),
@@ -289,6 +289,14 @@ def init_brain_extraction_wf(name='brain_extraction_wf',
         (apply_mask, outputnode, [('out_file', 'bias_corrected')]),
         (inu_n4, outputnode, [('bias_image', 'bias_image')]),
     ])
+
+    if use_laplacian:
+        wf.connect([
+            (inu_n4, lap_target, [
+                (('output_image', _pop), 'op1')]),
+            (lap_tmpl, mrg_tmpl, [('output_image', 'in2')]),
+            (lap_target, mrg_target, [('output_image', 'in2')])
+        ])
 
     if atropos_refine:
         atropos_wf = init_atropos_wf(


### PR DESCRIPTION
* Use of Laplacian alignment as a criterion during the final (CC-based) registration stage is made optional.
* The `bspline_fitting_distance` is measured in mm. The default setting of 200 can become problematic when images have a smaller FoV, as is often the case in small animal neuroimaging. Thus, setting this value is also made available as an option.